### PR TITLE
Several fixes to the reference implementation and alignment

### DIFF
--- a/app/extensions/chacha/chacha_ref.inc
+++ b/app/extensions/chacha/chacha_ref.inc
@@ -40,6 +40,7 @@ chacha_blocks_ref(chacha_state_internal *state, const unsigned char *in, unsigne
 	chacha_int32 t;
 	unsigned char *ctarget = out, tmp[64];
 	size_t i, r;
+	volatile chacha_int32 *cl;
 
 	if (!bytes) return;
 
@@ -172,11 +173,15 @@ chacha_blocks_ref(chacha_state_internal *state, const unsigned char *in, unsigne
 			/* store the counter back to the state */
 			U32TO8(state->s + 32, j[8]);
 			U32TO8(state->s + 36, j[9]);
-			return;
+			goto cleanup;
 		}
 		bytes -= 64;
 		out += 64;
 	}
+
+cleanup:
+	/* clean j as it contains sensitive info */
+	for(i = 0, cl = &j[0]; i < 16; i++, cl++) *cl = 0;
 }
 
 static void

--- a/app/extensions/chacha/impl.c
+++ b/app/extensions/chacha/impl.c
@@ -8,7 +8,7 @@ enum chacha_constants {
 	CHACHA_BLOCKBYTES = 64,
 };
 
-typedef struct chacha_state_internal_t {
+CHACHA_ALIGN(64) typedef struct chacha_state_internal_t {
 	unsigned char s[48];
 	size_t rounds;
 	size_t leftover;

--- a/app/extensions/chacha/impl.c
+++ b/app/extensions/chacha/impl.c
@@ -257,6 +257,9 @@ chacha_set_test_counter(chacha_state *S) {
 LIB_PUBLIC size_t
 chacha_final(chacha_state *S, unsigned char *out) {
 	chacha_state_internal *state = (chacha_state_internal *)S;
+	size_t ret, i;
+	volatile unsigned char *cl;
+
 	if (state->leftover) {
 		if (chacha_is_aligned(out)) {
 			chacha_opt->chacha_blocks(state, state->buffer, out, state->leftover);
@@ -265,8 +268,11 @@ chacha_final(chacha_state *S, unsigned char *out) {
 			memcpy(out, state->buffer, state->leftover);
 		}
 	}
-	memset(S, 0, sizeof(chacha_state));
-	return state->leftover;
+	ret = state->leftover;
+	cl = (volatile unsigned char *)S;
+	for(i = 0; i < sizeof(*state); i ++) cl[i] = '\0';
+
+	return ret;
 }
 
 /* one-shot, input/output assumed to be word aligned */

--- a/app/include/chacha.h
+++ b/app/include/chacha.h
@@ -7,11 +7,19 @@
 	#define LIB_PUBLIC
 #endif
 
+#ifndef CHACHA_ALIGN
+# if defined(_MSC_VER)
+#  define CHACHA_ALIGN(x) __declspec(align(x))
+# else
+#  define CHACHA_ALIGN(x) __attribute__((aligned(x)))
+# endif
+#endif
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
 
-typedef struct chacha_state_t {
+CHACHA_ALIGN(64) typedef struct chacha_state_t {
 	unsigned char opaque[128];
 } chacha_state;
 


### PR DESCRIPTION
I have found that using chacha-opt with avx2 is not possible unless chacha_state structure is aligned on 64 bytes boundary. Therefore, I have added explicit alignment for this structure that has fixed the problem. Moreover, the reference implementation leaves session key in the stack variable named `j` after `chacha_blocks` function. I suppose, cleaning is a desired behaviour in this case.
